### PR TITLE
feat. STOMP WebSocket 서버 기본 설정

### DIFF
--- a/src/main/java/com/smooth/alert_service/config/WebSocketConfig.java
+++ b/src/main/java/com/smooth/alert_service/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.smooth.alert_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/user");
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
+    }
+}

--- a/src/main/java/com/smooth/alert_service/controller/TestAlertController.java
+++ b/src/main/java/com/smooth/alert_service/controller/TestAlertController.java
@@ -1,0 +1,22 @@
+package com.smooth.alert_service.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestAlertController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @PostMapping("/test-alert")
+    public ResponseEntity<String> sendTestAlert(@RequestParam String userId) {
+        String message = "🚨 테스트 알림: 서버에서 " + userId + "에게 전송됨";
+        messagingTemplate.convertAndSendToUser(userId, "/alert", message);
+        return ResponseEntity.ok("✅ 전송됨: " + userId);
+    }
+}


### PR DESCRIPTION
- `/ws` endpoint 등록 및 SockJS 지원
- SimpleBroker에 `/user `prefix 설정
- convertAndSendToUser 기반 개인 메시지 전송 구조 구현
- 클라이언트의 `/user/queue/alert` 구독 지원
- 테스트용 컨트롤러(TestAlertController) 추가