### PR TITLE
feat. 사용자 WebSocket 세션 Redis 등록 기능 구현(1인 1룸 연결 관리)

### DIFF
--- a/src/main/java/com/smooth/alert_service/config/RedisConfig.java
+++ b/src/main/java/com/smooth/alert_service/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.smooth.alert_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+        
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/smooth/alert_service/controller/TestTokenController.java
+++ b/src/main/java/com/smooth/alert_service/controller/TestTokenController.java
@@ -1,0 +1,42 @@
+package com.smooth.alert_service.controller;
+
+import com.smooth.alert_service.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/dev")
+@RequiredArgsConstructor
+@Profile("dev") // 개발 환경에서만 활성화
+public class TestTokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/test-token")
+    public ResponseEntity<?> generateTestToken(@RequestParam String userId) {
+
+        if (!StringUtils.hasText(userId)) {
+            return ResponseEntity.badRequest().body("userId는 필수입니다.");
+        }
+        
+        if (userId.length() > 50) {
+            return ResponseEntity.badRequest().body("userId는 50자를 초과할 수 없습니다.");
+        }
+
+        try {
+            String token = jwtTokenProvider.createTestToken(userId);
+            return ResponseEntity.ok(new TokenResponse("Bearer " + token, userId));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("토큰 생성 실패: " + e.getMessage());
+        }
+    }
+    
+    // 응답 DTO
+    public record TokenResponse(String token, String userId) {}
+}

--- a/src/main/java/com/smooth/alert_service/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/smooth/alert_service/jwt/JwtTokenProvider.java
@@ -1,0 +1,48 @@
+package com.smooth.alert_service.jwt;
+
+import com.smooth.alert_service.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    public String getUserId(String token) {
+        SecretKey key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+        
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.getSubject();
+    }
+
+    // test용 임시 token 발급
+    public String createTestToken(String userId) {
+        SecretKey key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+        
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + jwtProperties.getExpiration());
+
+        return Jwts.builder()
+                .subject(userId)
+                .issuer("alert-service")
+                .issuedAt(now)
+                .expiration(expiration)
+                .claim("type", "test")
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/smooth/alert_service/websocket/SessionEventListener.java
+++ b/src/main/java/com/smooth/alert_service/websocket/SessionEventListener.java
@@ -1,0 +1,77 @@
+package com.smooth.alert_service.websocket;
+
+import com.smooth.alert_service.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SessionEventListener {
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String token = accessor.getFirstNativeHeader("Authorization");
+
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+            try {
+                String userId = jwtTokenProvider.getUserId(token);
+                String sessionId = accessor.getSessionId();
+
+                if (sessionId == null) {
+                    log.warn("❌ SessionId가 null입니다. userId={}", userId);
+                    return;
+                }
+
+                // 기존 세션이 있다면 정리
+                String existingSessionKey = "session:" + userId;
+                String existingSessionId = redisTemplate.opsForValue().get(existingSessionKey);
+                if (existingSessionId != null) {
+                    redisTemplate.delete("user:" + existingSessionId);
+                }
+
+                // 새 세션 매핑 저장
+                redisTemplate.opsForValue().set(existingSessionKey, sessionId, Duration.ofHours(3));
+                redisTemplate.opsForValue().set("user:" + sessionId, userId, Duration.ofHours(3));
+                
+                log.info("✅ WebSocket CONNECT: userId={}, sessionId={}", userId, sessionId);
+            } catch (Exception e) {
+                log.warn("⚠️ JWT 파싱 실패: {}", e.getMessage());
+            }
+        } else {
+            log.warn("❌ Authorization 헤더 없음");
+        }
+    }
+
+    @EventListener
+    public void handleWebsocketDisconnectListener(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        
+        if (sessionId == null) {
+            log.warn("❌ DISCONNECT 이벤트에서 SessionId가 null입니다.");
+            return;
+        }
+
+        String userId = redisTemplate.opsForValue().get("user:" + sessionId);
+        if (userId != null) {
+            redisTemplate.delete("session:" + userId);
+            redisTemplate.delete("user:" + sessionId);
+            log.info("🛑 WebSocket DISCONNECT: userId={}, sessionId={}", userId, sessionId);
+        } else {
+            log.info("🛑 WebSocket DISCONNECT: sessionId={} (사용자 정보 없음)", sessionId);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,11 +30,11 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
 jwt:
-  secret: dev-jwt-secret-key
+  secret: dev-jwt-secret-key-must-be-at-least-32-characters-long-for-security
   expiration: 3600000 # 1시간
 
 logging:
   level:
     root: INFO
-    com.yourcompany.alertservice: DEBUG
+    com.smooth.alert_service: DEBUG
     org.springframework.web: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,6 +5,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD}
       timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 5
+          min-idle: 2
 
   datasource:
     url: jdbc:mysql://prod-db-host:3306/alert_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -37,5 +42,5 @@ jwt:
 logging:
   level:
     root: INFO
-    com.yourcompany.alertservice: INFO
+    com.smooth.alert_service: INFO
     org.springframework.web: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,4 +21,4 @@ server:
 logging:
   level:
     root: INFO
-    com.yourcompany.alertservice: INFO
+    com.smooth.alert_service: INFO


### PR DESCRIPTION
- WebSocket 접속(SessionConnectEvent) 시 userId 기반 Redis 키 저장: session:{userId}
- WebSocket 종료(SessionDisconnectEvent) 시 Redis 세션 키 삭제
- SessionEventListener 클래스 구현
- JwtTokenProvider 내부 JWT 파싱 로직 수정 (현 버전에 맞게 Claims 파싱)
- 테스트용 JWT 토큰 발급 컨트롤러 추가 (/dev/test-token)
- RedisTemplate 설정 추가
- HTML 기반 WebSocket 다중 사용자 테스트 완료