### PR TITLE
feat. 사고 유형별 알림 메시지 매핑 로직 및 테스트 추가

### DIFF
--- a/src/main/java/com/smooth/alert_service/domain/AlertType.java
+++ b/src/main/java/com/smooth/alert_service/domain/AlertType.java
@@ -1,0 +1,33 @@
+package com.smooth.alert_service.domain;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum AlertType {
+    ACCIDENT("accident"),
+    OBSTACLE("obstacle"),
+    POTHOLE("pothole"),
+    START("start"),
+    END("end");
+
+    private final String value;
+
+    AlertType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Optional<AlertType> from(String value) {
+        return Arrays.stream(values())
+                .filter(t->t.value.equalsIgnoreCase(value))
+                .findFirst();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/com/smooth/alert_service/dto/AlertEvent.java
+++ b/src/main/java/com/smooth/alert_service/dto/AlertEvent.java
@@ -1,0 +1,13 @@
+package com.smooth.alert_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AlertEvent(
+        String type,
+        String accidentId,
+        String userId,
+        Double latitude,
+        Double longitude,
+        String timestamp
+) {}

--- a/src/main/java/com/smooth/alert_service/dto/AlertMessageDto.java
+++ b/src/main/java/com/smooth/alert_service/dto/AlertMessageDto.java
@@ -1,0 +1,7 @@
+package com.smooth.alert_service.dto;
+
+public record AlertMessageDto(
+        String type,
+        String title,
+        String content
+) {}

--- a/src/main/java/com/smooth/alert_service/mapper/AlertMessageMapper.java
+++ b/src/main/java/com/smooth/alert_service/mapper/AlertMessageMapper.java
@@ -1,0 +1,63 @@
+package com.smooth.alert_service.mapper;
+
+import com.smooth.alert_service.domain.AlertType;
+import com.smooth.alert_service.dto.AlertEvent;
+import com.smooth.alert_service.dto.AlertMessageDto;
+
+import java.util.Optional;
+
+public class AlertMessageMapper {
+
+    public static Optional<AlertMessageDto> map(AlertEvent event, String targetUserId) {
+        AlertType type = AlertType.from(event.type())
+                .orElseThrow(() -> new IllegalArgumentException("invalid alert type: " + event.type()));
+
+        boolean isSelf = event.userId() != null && event.userId().equals(targetUserId);
+
+        AlertMessageDto message = switch (type) {
+            case ACCIDENT -> {
+                if (isSelf) {
+                    yield new AlertMessageDto(
+                            "accident",
+                            "큰 사고가 발생했습니다",
+                            "차량에 큰 사고가 감지되었습니다. 부상이 있다면 즉시 구조를 요청하세요."
+                    );
+                } else {
+                    yield new AlertMessageDto(
+                            "accident-nearby",
+                            "전방 사고 발생",
+                            "전방에 큰 사고가 발생했습니다. 속도를 줄이고 주의하세요."
+                    );
+                }
+            }
+            case OBSTACLE -> {
+                if (isSelf) {
+                    yield null; // 본인에게는 전송하지 않음
+                } else {
+                    yield new AlertMessageDto(
+                            "obstacle",
+                            "전방 장애물 발견",
+                            "전방에 장애물이 있습니다. 주의해서 운전하세요."
+                    );
+                }
+            }
+            case POTHOLE -> new AlertMessageDto(
+                    "pothole",
+                    "포트홀 발견",
+                    "전방에 포트홀이 있습니다. 속도를 줄이고 주의해서 주행하세요."
+            );
+            case START -> new AlertMessageDto(
+                    "start",
+                    "주행 시작",
+                    "안전운전하세요!"
+            );
+            case END -> new AlertMessageDto(
+                    "end",
+                    "주행 종료",
+                    "수고하셨습니다. 휴식을 취하세요!"
+            );
+        };
+
+        return Optional.ofNullable(message);
+    }
+}

--- a/src/main/java/com/smooth/alert_service/validator/AlertEventValidator.java
+++ b/src/main/java/com/smooth/alert_service/validator/AlertEventValidator.java
@@ -1,0 +1,47 @@
+package com.smooth.alert_service.validator;
+
+import com.smooth.alert_service.domain.AlertType;
+import com.smooth.alert_service.dto.AlertEvent;
+
+public class AlertEventValidator {
+
+    public static void validate(AlertEvent event) {
+        if (event.type() == null || event.type().isBlank()) {
+            throw new IllegalArgumentException("type is required");
+        }
+
+        AlertType type = AlertType.from(event.type())
+                .orElseThrow(() -> new IllegalArgumentException("invalid alert type: " + event.type()));
+
+        switch (type) {
+            case ACCIDENT -> {
+                require(event.accidentId(), "accidentId is required for type=accident");
+                require(event.userId(), "userId is required for type=accident");
+                require(event.latitude(), "latitude is required for type=accident");
+                require(event.longitude(), "longitude is required for type=accident");
+                require(event.timestamp(), "timestamp is required for type=accident");
+            }
+            case OBSTACLE -> {
+                require(event.userId(), "userId is required for type=obstacle");
+                require(event.latitude(), "latitude is required for type=obstacle");
+                require(event.longitude(), "longitude is required for type=obstacle");
+                require(event.timestamp(), "timestamp is required for type=obstacle");
+            }
+            case POTHOLE -> {
+                require(event.latitude(), "latitude is required for type=pothole");
+                require(event.longitude(), "longitude is required for type=pothole");
+                require(event.timestamp(), "timestamp is required for type=pothole");
+            }
+            case START, END -> {
+                require(event.userId(), "userId is required for type=" + type);
+                require(event.timestamp(), "timestamp is required for type=" + type);
+            }
+        }
+    }
+
+    private static void require(Object value, String message) {
+        if (value == null || (value instanceof String str && str.isBlank())) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/src/test/java/com/smooth/alert_service/mapper/AlertMessageMapperTest.java
+++ b/src/test/java/com/smooth/alert_service/mapper/AlertMessageMapperTest.java
@@ -1,0 +1,94 @@
+package com.smooth.alert_service.mapper;
+
+import com.smooth.alert_service.dto.AlertEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AlertMessageMapperTest {
+
+    @Test
+    void 본인_사고는_accident_메시지로_매핑된다() {
+        // 올바른 필드 순서: type, accidentId, userId, latitude, longitude, timestamp
+        var event = new AlertEvent("accident", "acc-001", "driver1", 37.5, 126.9, "2025-08-04T17:00:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver1");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("accident");
+        assertThat(message.title()).contains("큰 사고");
+    }
+
+    @Test
+    void 다른사람의_사고는_accident_nearby_메시지로_매핑된다() {
+        var event = new AlertEvent("accident", "acc-002", "driver1", 37.5, 126.9, "2025-08-04T17:00:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver2");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("accident-nearby");
+        assertThat(message.title()).contains("전방 사고");
+    }
+
+    @Test
+    void 본인의_장애물은_빈_Optional을_반환한다() {
+        var event = new AlertEvent("obstacle", null, "driver1", 37.5, 126.9, "2025-08-04T17:01:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver1");
+
+        assertThat(messageOpt).isEmpty();
+    }
+
+    @Test
+    void 다른사람의_장애물은_obstacle_메시지로_매핑된다() {
+        var event = new AlertEvent("obstacle", null, "driver1", 37.5, 126.9, "2025-08-04T17:01:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver2");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("obstacle");
+        assertThat(message.title()).contains("전방 장애물");
+    }
+
+    @Test
+    void 포트홀은_무조건_pothole_메시지를_반환한다() {
+        var event = new AlertEvent("pothole", null, null, 37.5, 126.9, "2025-08-04T17:01:30Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver1");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("pothole");
+        assertThat(message.title()).contains("포트홀");
+    }
+
+    @Test
+    void 주행시작은_start_메시지를_반환한다() {
+        var event = new AlertEvent("start", null, "driver1", null, null, "2025-08-04T17:02:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver1");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("start");
+        assertThat(message.title()).contains("주행 시작");
+    }
+
+    @Test
+    void 주행종료는_end_메시지를_반환한다() {
+        var event = new AlertEvent("end", null, "driver1", null, null, "2025-08-04T17:03:00Z");
+        var messageOpt = AlertMessageMapper.map(event, "driver1");
+
+        assertThat(messageOpt).isPresent();
+        var message = messageOpt.get();
+        assertThat(message.type()).isEqualTo("end");
+        assertThat(message.title()).contains("주행 종료");
+    }
+
+    @Test
+    void 잘못된_type이면_예외가_발생한다() {
+        var event = new AlertEvent("invalid", null, "driver1", null, null, "2025-08-04T17:04:00Z");
+
+        assertThatThrownBy(() -> AlertMessageMapper.map(event, "driver1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid alert type");
+    }
+}


### PR DESCRIPTION
- AlertEvent 기반 알림 메시지 생성 로직 구현 (AlertMessageMapper)
- type에 따라 메시지 type/title/content 분기 처리
  - accident (본인): 사고 알림
  - accident-nearby (타인): 근처 사고 알림
  - obstacle (타인): 장애물 알림
  - pothole: 포트홀 알림
  - start/end: 주행 시작/종료 알림
- 본인 장애물 이벤트는 제외 처리
- invalid type 입력 시 IllegalArgumentException 발생
- 단위 테스트 (AlertMessageMapperTest) 작성 및 통과