### PR TITLE
feat: Redis를 이용한 중복 알림 방지 로직 추가

### DIFF
--- a/src/main/java/com/smooth/alert_service/api/test/TestAlertController.java
+++ b/src/main/java/com/smooth/alert_service/api/test/TestAlertController.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.controller;
+package com.smooth.alert_service.api.test;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/smooth/alert_service/api/test/TestTokenController.java
+++ b/src/main/java/com/smooth/alert_service/api/test/TestTokenController.java
@@ -1,6 +1,6 @@
-package com.smooth.alert_service.controller;
+package com.smooth.alert_service.api.test;
 
-import com.smooth.alert_service.jwt.JwtTokenProvider;
+import com.smooth.alert_service.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/smooth/alert_service/config/SessionEventListener.java
+++ b/src/main/java/com/smooth/alert_service/config/SessionEventListener.java
@@ -1,6 +1,6 @@
-package com.smooth.alert_service.websocket;
+package com.smooth.alert_service.config;
 
-import com.smooth.alert_service.jwt.JwtTokenProvider;
+import com.smooth.alert_service.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;

--- a/src/main/java/com/smooth/alert_service/core/AlertEventHandler.java
+++ b/src/main/java/com/smooth/alert_service/core/AlertEventHandler.java
@@ -1,0 +1,40 @@
+package com.smooth.alert_service.core;
+
+import com.smooth.alert_service.model.AlertType;
+import com.smooth.alert_service.model.AlertEvent;
+import com.smooth.alert_service.support.validator.AlertEventValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlertEventHandler {
+
+    private final AlertRepeatNotifier alertRepeatNotifier;
+
+    public void handle(AlertEvent event) {
+        log.info("알림 이벤트 수신: type={}, userId={}, time={}", event.type(), event.userId(), event.timestamp());
+
+        try {
+            AlertEventValidator.validate(event);
+            
+            var alertType = AlertType.from(event.type());
+            if (alertType.isEmpty()) {
+                log.warn("알 수 없는 알림 타입: {}", event.type());
+                return;
+            }
+
+            if (alertType.get() == AlertType.ACCIDENT || alertType.get() == AlertType.OBSTACLE) {
+                alertRepeatNotifier.start(event);
+            } else {
+                log.info("반복 전송 대상 아님: type={}", event.type());
+            }
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 이벤트 데이터: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("이벤트 처리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/smooth/alert_service/core/AlertMessageMapper.java
+++ b/src/main/java/com/smooth/alert_service/core/AlertMessageMapper.java
@@ -1,8 +1,8 @@
-package com.smooth.alert_service.mapper;
+package com.smooth.alert_service.core;
 
-import com.smooth.alert_service.domain.AlertType;
-import com.smooth.alert_service.dto.AlertEvent;
-import com.smooth.alert_service.dto.AlertMessageDto;
+import com.smooth.alert_service.model.AlertType;
+import com.smooth.alert_service.model.AlertEvent;
+import com.smooth.alert_service.model.AlertMessageDto;
 
 import java.util.Optional;
 

--- a/src/main/java/com/smooth/alert_service/core/AlertRepeatNotifier.java
+++ b/src/main/java/com/smooth/alert_service/core/AlertRepeatNotifier.java
@@ -1,0 +1,67 @@
+package com.smooth.alert_service.core;
+
+import com.smooth.alert_service.model.AlertEvent;
+import com.smooth.alert_service.repository.AlertCacheService;
+import com.smooth.alert_service.support.util.AlertIdResolver;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlertRepeatNotifier {
+
+    private final VicinityUserFinder vicinityUserFinder;
+    private final AlertCacheService alertCacheService;
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(
+            2,
+            new CustomizableThreadFactory("alert-repeat-")
+    );
+
+    public void start(AlertEvent event) {
+        Optional<String> alertIdOpt = AlertIdResolver.resolve(event);
+        if(alertIdOpt.isEmpty()) {
+            log.info("반복 알림 제외 대상: type={}, userId={}", event.type(), event.userId());
+            return;
+        }
+
+        String alertId = alertIdOpt.get();
+        Instant endTime = Instant.now().plus(Duration.ofMinutes(3));
+
+        var scheduledFuture = scheduler.scheduleAtFixedRate(() -> {
+            try {
+                if (Instant.now().isAfter(endTime)) {
+                    log.info("알림 반복 종료: alertId={}", alertId);
+                    return;
+                }
+                
+                List<String> nearbyUsers = vicinityUserFinder.findNearbyUsers(event);
+                for (String userId : nearbyUsers) {
+                    if (alertCacheService.isAlreadySent(alertId, userId)) continue;
+
+                    log.info("알림 전송 예정(전송 로직은 T5.1.6에서 구현): alertId={}, userId={}", alertId, userId);
+                    alertCacheService.markAsSent(alertId, userId);
+                }
+            } catch (Exception e) {
+                log.error("알림 반복 처리 중 오류 발생: alertId={}", alertId, e);
+            }
+        }, 0, 10, TimeUnit.SECONDS);
+
+        // 3분 후 스케줄러 자동 종료
+        scheduler.schedule(() -> {
+            scheduledFuture.cancel(false);
+            log.info("알림 반복 스케줄러 종료: alertId={}", alertId);
+        }, 3, TimeUnit.MINUTES);
+    }
+}

--- a/src/main/java/com/smooth/alert_service/core/VicinityUserFinder.java
+++ b/src/main/java/com/smooth/alert_service/core/VicinityUserFinder.java
@@ -1,7 +1,7 @@
-package com.smooth.alert_service.service;
+package com.smooth.alert_service.core;
 
-import com.smooth.alert_service.domain.EventType;
-import com.smooth.alert_service.dto.AlertEvent;
+import com.smooth.alert_service.model.EventType;
+import com.smooth.alert_service.model.AlertEvent;
 import org.springframework.data.geo.*;
 import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.core.GeoOperations;

--- a/src/main/java/com/smooth/alert_service/model/AlertEvent.java
+++ b/src/main/java/com/smooth/alert_service/model/AlertEvent.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.dto;
+package com.smooth.alert_service.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/java/com/smooth/alert_service/model/AlertMessageDto.java
+++ b/src/main/java/com/smooth/alert_service/model/AlertMessageDto.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.dto;
+package com.smooth.alert_service.model;
 
 public record AlertMessageDto(
         String type,

--- a/src/main/java/com/smooth/alert_service/model/AlertType.java
+++ b/src/main/java/com/smooth/alert_service/model/AlertType.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.domain;
+package com.smooth.alert_service.model;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/src/main/java/com/smooth/alert_service/model/EventType.java
+++ b/src/main/java/com/smooth/alert_service/model/EventType.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.domain;
+package com.smooth.alert_service.model;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/src/main/java/com/smooth/alert_service/repository/AlertCacheService.java
+++ b/src/main/java/com/smooth/alert_service/repository/AlertCacheService.java
@@ -1,0 +1,43 @@
+package com.smooth.alert_service.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+public class AlertCacheService {
+
+    private static final Duration TTL = Duration.ofMinutes(3);
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public AlertCacheService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public boolean isAlreadySent(String alertId, String userId) {
+        try {
+            String key = buildKey(alertId, userId);
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            log.error("Redis 조회 실패: alertId={}, userId={}", alertId, userId, e);
+            return false;
+        }
+    }
+
+    public void markAsSent(String alertId, String userId) {
+        try {
+            String key = buildKey(alertId, userId);
+            redisTemplate.opsForValue().set(key, "sent", TTL);
+            log.debug("알림 전송 기록 저장: key={}", key);
+        } catch (Exception e) {
+            log.error("Redis 저장 실패: alertId={}, userId={}", alertId, userId, e);
+        }
+    }
+
+    private String buildKey(String alertId, String userId) {
+        return "alert_sent:" + alertId + ":" + userId;
+    }
+}

--- a/src/main/java/com/smooth/alert_service/security/JwtProperties.java
+++ b/src/main/java/com/smooth/alert_service/security/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.smooth.alert_service.config;
+package com.smooth.alert_service.security;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/smooth/alert_service/security/JwtTokenProvider.java
+++ b/src/main/java/com/smooth/alert_service/security/JwtTokenProvider.java
@@ -1,6 +1,5 @@
-package com.smooth.alert_service.jwt;
+package com.smooth.alert_service.security;
 
-import com.smooth.alert_service.config.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/smooth/alert_service/support/util/AlertIdResolver.java
+++ b/src/main/java/com/smooth/alert_service/support/util/AlertIdResolver.java
@@ -1,0 +1,17 @@
+package com.smooth.alert_service.support.util;
+
+import com.smooth.alert_service.model.AlertEvent;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class AlertIdResolver {
+
+    public static Optional<String> resolve(AlertEvent event) {
+        return switch (event.type()) {
+            case "accident" -> Optional.ofNullable(event.accidentId());
+            case "obstacle" -> Optional.of("obstacle-" + UUID.randomUUID().toString());
+            default -> Optional.empty();
+        };
+    }
+}

--- a/src/main/java/com/smooth/alert_service/support/validator/AlertEventValidator.java
+++ b/src/main/java/com/smooth/alert_service/support/validator/AlertEventValidator.java
@@ -1,7 +1,7 @@
-package com.smooth.alert_service.validator;
+package com.smooth.alert_service.support.validator;
 
-import com.smooth.alert_service.domain.AlertType;
-import com.smooth.alert_service.dto.AlertEvent;
+import com.smooth.alert_service.model.AlertType;
+import com.smooth.alert_service.model.AlertEvent;
 
 public class AlertEventValidator {
 

--- a/src/test/java/com/smooth/alert_service/mapper/AlertMessageMapperTest.java
+++ b/src/test/java/com/smooth/alert_service/mapper/AlertMessageMapperTest.java
@@ -1,6 +1,7 @@
 package com.smooth.alert_service.mapper;
 
-import com.smooth.alert_service.dto.AlertEvent;
+import com.smooth.alert_service.core.AlertMessageMapper;
+import com.smooth.alert_service.model.AlertEvent;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/smooth/alert_service/redis/AlertCacheServiceTest.java
+++ b/src/test/java/com/smooth/alert_service/redis/AlertCacheServiceTest.java
@@ -1,0 +1,38 @@
+package com.smooth.alert_service.redis;
+
+import com.smooth.alert_service.repository.AlertCacheService;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class AlertCacheServiceTest {
+
+    @SuppressWarnings("unchecked")
+    RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+    @SuppressWarnings("unchecked")
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+
+    AlertCacheService cacheService = new AlertCacheService(redisTemplate);
+
+    @Test
+    void 알림이_이미_전송되었는지_확인한다() {
+        when(redisTemplate.hasKey("alert:acc-123:user-456")).thenReturn(true);
+
+        boolean result = cacheService.isAlreadySent("acc-123", "user-456");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 알림_전송_이력을_저장한다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+        cacheService.markAsSent("acc-123", "user-456");
+
+        verify(valueOps, times(1))
+                .set(eq("alert:acc-123:user-456"), eq("sent"), any());
+    }
+}

--- a/src/test/java/com/smooth/alert_service/scheduler/AlertRepeatNotifierTest.java
+++ b/src/test/java/com/smooth/alert_service/scheduler/AlertRepeatNotifierTest.java
@@ -1,0 +1,68 @@
+package com.smooth.alert_service.scheduler;
+
+import com.smooth.alert_service.core.AlertRepeatNotifier;
+import com.smooth.alert_service.model.AlertEvent;
+import com.smooth.alert_service.repository.AlertCacheService;
+import com.smooth.alert_service.core.VicinityUserFinder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class AlertRepeatNotifierTest {
+
+    private VicinityUserFinder vicinityUserFinder;
+    private AlertCacheService alertCacheService;
+    private AlertRepeatNotifier notifier;
+
+    @BeforeEach
+    void setUp() {
+        vicinityUserFinder = mock(VicinityUserFinder.class);
+        alertCacheService = mock(AlertCacheService.class);
+        notifier = new AlertRepeatNotifier(vicinityUserFinder, alertCacheService);
+    }
+
+    @Test
+    void 알림이_3분동안_중복없이_전송된다() throws InterruptedException {
+        // given
+        var event = new AlertEvent("accident", "acc-123", "driver-1", 37.5, 126.9, "2025-08-05T20:00:00Z");
+
+        when(vicinityUserFinder.findNearbyUsers(event))
+                .thenReturn(List.of("userA", "userB"));
+        when(alertCacheService.isAlreadySent("acc-123", "userA")).thenReturn(false);
+        when(alertCacheService.isAlreadySent("acc-123", "userB")).thenReturn(false);
+
+        // when
+        notifier.start(event);
+
+        // then (wait for scheduler to run at least once)
+        Thread.sleep(1200); // allow time for scheduler to execute
+
+        verify(alertCacheService, atLeastOnce()).isAlreadySent("acc-123", "userA");
+        verify(alertCacheService, atLeastOnce()).markAsSent("acc-123", "userA");
+        verify(alertCacheService, atLeastOnce()).markAsSent("acc-123", "userB");
+    }
+
+
+    @Test
+    void 이미_전송된_사용자는_건너뛴다() throws InterruptedException {
+        // given
+        var event = new AlertEvent("accident", "acc-999", "driver-9", 37.5, 126.9, "2025-08-05T20:03:00Z");
+
+        when(vicinityUserFinder.findNearbyUsers(event))
+                .thenReturn(List.of("userX", "userY"));
+        when(alertCacheService.isAlreadySent("acc-999", "userX")).thenReturn(true);
+        when(alertCacheService.isAlreadySent("acc-999", "userY")).thenReturn(false);
+
+        // when
+        notifier.start(event);
+
+        // then
+        Thread.sleep(1200); // allow time for scheduler to execute
+
+        verify(alertCacheService, never()).markAsSent("acc-999", "userX");
+        verify(alertCacheService, atLeastOnce()).markAsSent("acc-999", "userY");
+    }
+}

--- a/src/test/java/com/smooth/alert_service/service/VicinityUserFinderTest.java
+++ b/src/test/java/com/smooth/alert_service/service/VicinityUserFinderTest.java
@@ -1,6 +1,7 @@
 package com.smooth.alert_service.service;
 
-import com.smooth.alert_service.dto.AlertEvent;
+import com.smooth.alert_service.core.VicinityUserFinder;
+import com.smooth.alert_service.model.AlertEvent;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.geo.*;
 import org.springframework.data.redis.connection.RedisGeoCommands;


### PR DESCRIPTION
- alert:{alertId}:{userId} 키 구조로 중복 여부 판단
- AlertCacheService: Redis 연동 및 TTL 설정 (기본 3분)
- AlertRepeatNotifier: 메시지 전송 전 중복 체크 → 중복 아니면 전송 및 Redis 저장
- 중복 여부 판단 테스트 코드 추가 (AlertRepeatNotifierTest, AlertCacheServiceTest)