### PR TITLE
refactor: 반경 필터링 시 location:{timestamp} 최신 키 탐색 구조 적용

### DIFF
--- a/src/main/java/com/smooth/alert_service/support/util/LatestLocationKeyFinder.java
+++ b/src/main/java/com/smooth/alert_service/support/util/LatestLocationKeyFinder.java
@@ -1,0 +1,29 @@
+package com.smooth.alert_service.support.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class LatestLocationKeyFinder {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.ofHours(9));
+
+    public String findLatestKey(Instant baseTime, int maxSeconds) {
+        for (int i = 0; i <= maxSeconds; i++) {
+            Instant time = baseTime.minusSeconds(i);
+            String key = "location:" + FORMATTER.format(time);
+            if (redisTemplate.hasKey(key)) {
+                return key;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- VicinityUserFinder: 키를 직접 주입할 수 있도록 메서드 오버로드 추가
- AlertRepeatNotifier: 최초 조회는 location:{timestamp}, 이후는 최근 키 기반 반복 조회로 분리
- LatestLocationKeyFinder: 현재 시각 기준 가장 최신 timestamp 키 탐색 유틸 추가
- AlertMessageMapper: 본인 사고 여부 기반 메시지 분기 처리 (accident vs accident-nearby 등)
- Redis 키 하드코딩 제거, 실시간 반경 필터링을 발키 제약 내에서 유연하게 처리

Fixes: #11 